### PR TITLE
add "maintenanceids" to ignored fields

### DIFF
--- a/pypingdom/check.py
+++ b/pypingdom/check.py
@@ -7,7 +7,7 @@ class Check(object):
     SKIP_ON_PRINT = ["cached_definition", "_id", "api"]
     SKIP_ON_JSON = [
         "api", "alert_policy_name", "cached_definition", "created", "lastresponsetime",
-        "lasttesttime", "lasterrortime", "_id", "id", "status"
+        "lasttesttime", "lasterrortime", "_id", "id", "status", "maintenanceids"
     ]
 
     def __init__(self, api, json=False, obj=False):


### PR DESCRIPTION
When updating the check, api endpoint doesn't understand "maintenanceids" field, that is present in https://api.pingdom.com/api/2.1/checks output